### PR TITLE
Feat: Add OpenFGA authorization service and wiring

### DIFF
--- a/src/bruno/OpenFGA/Check Access.bru
+++ b/src/bruno/OpenFGA/Check Access.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Check Access
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/stores/{{storeId}}/check
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "tuple_key": {
+      "user": "user:mads",
+      "relation": "can_view",
+      "object": "file:report"
+    },
+    "authorization_model_id": "{{authorizationModelId}}"
+  }
+}
+
+settings {
+  encodeUrl: true
+}

--- a/src/bruno/OpenFGA/Create Model.bru
+++ b/src/bruno/OpenFGA/Create Model.bru
@@ -1,0 +1,74 @@
+meta {
+  name: Create Model
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/stores/{{storeId}}/authorization-models
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "schema_version": "1.1",
+    "type_definitions": [
+      { "type": "user" },
+      {
+        "type": "folder",
+        "relations": {
+          "owner": { "this": {} },
+          "viewer": { "this": {} },
+          "can_view": {
+            "union": {
+              "child": [
+                { "computedUserset": { "relation": "owner" } },
+                { "computedUserset": { "relation": "viewer" } }
+              ]
+            }
+          }
+        },
+        "metadata": {
+          "relations": {
+            "owner": { "directly_related_user_types": [{ "type": "user" }] },
+            "viewer": { "directly_related_user_types": [{ "type": "user" }] }
+          }
+        }
+      },
+      {
+        "type": "file",
+        "relations": {
+          "owner": { "this": {} },
+          "viewer": { "this": {} },
+          "parent": { "this": {} },
+          "can_view": {
+            "union": {
+              "child": [
+                { "computedUserset": { "relation": "owner" } },
+                { "computedUserset": { "relation": "viewer" } },
+                {
+                  "tupleToUserset": {
+                    "tupleset": { "relation": "parent" },
+                    "computedUserset": { "relation": "can_view" }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "metadata": {
+          "relations": {
+            "owner": { "directly_related_user_types": [{ "type": "user" }] },
+            "viewer": { "directly_related_user_types": [{ "type": "user" }] },
+            "parent": { "directly_related_user_types": [{ "type": "folder" }] }
+          }
+        }
+      }
+    ]
+  }
+}
+
+settings {
+  encodeUrl: true
+}

--- a/src/bruno/OpenFGA/Create Store.bru
+++ b/src/bruno/OpenFGA/Create Store.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Create Store
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/stores
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "name": "fileshare"
+  }
+}
+
+settings {
+  encodeUrl: true
+}

--- a/src/bruno/OpenFGA/Get File Contents.bru
+++ b/src/bruno/OpenFGA/Get File Contents.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get File Contents
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/files/{fileId}/contents
+  body: none
+  auth: none
+}
+
+settings {
+  encodeUrl: true
+}

--- a/src/bruno/OpenFGA/Write Tuples.bru
+++ b/src/bruno/OpenFGA/Write Tuples.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Write Tuples
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/stores/{{storeId}}/write
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "writes": {
+      "tuple_keys": [
+        {
+          "user": "user:mads",
+          "relation": "owner",
+          "object": "folder:thesis"
+        },
+        {
+          "user": "folder:thesis",
+          "relation": "parent",
+          "object": "file:report"
+        }
+      ]
+    },
+    "authorization_model_id": "{{authorizationModelId}}"
+  }
+}
+
+settings {
+  encodeUrl: true
+}

--- a/src/bruno/OpenFGA/bruno.json
+++ b/src/bruno/OpenFGA/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "OpenFGA",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/src/bruno/OpenFGA/collection.bru
+++ b/src/bruno/OpenFGA/collection.bru
@@ -1,0 +1,13 @@
+meta {
+  name: OpenFGA
+}
+
+auth {
+  mode: none
+}
+
+vars:pre-request {
+  baseUrl: 
+  storeId: 
+  authorizationModelId: 
+}

--- a/src/bruno/OpenFGA/environments/local.bru
+++ b/src/bruno/OpenFGA/environments/local.bru
@@ -1,0 +1,6 @@
+vars {
+  baseUrl: http://localhost:8080
+}
+vars:secret [
+  bearerToken
+]

--- a/src/svc/storage/Configuration/OpenFgaConfig.cs
+++ b/src/svc/storage/Configuration/OpenFgaConfig.cs
@@ -1,7 +1,8 @@
-using System.Net.Http.Json;
-using Microsoft.Extensions.Options;
+namespace Storage.Configuration;
 
-public interface IAuthorizationService
+public class OpenFgaConfig
 {
-    Task<bool> CanViewFile(string userId, string fileId);
+    public string ApiUrl { get; set; } = "";
+    public string StoreId { get; set; } = "";
+    public string AuthorizationModelId { get; set; } = "";
 }

--- a/src/svc/storage/Configuration/OpenFgaConfig.cs
+++ b/src/svc/storage/Configuration/OpenFgaConfig.cs
@@ -1,0 +1,7 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Options;
+
+public interface IAuthorizationService
+{
+    Task<bool> CanViewFile(string userId, string fileId);
+}

--- a/src/svc/storage/Controllers/FileController.cs
+++ b/src/svc/storage/Controllers/FileController.cs
@@ -30,6 +30,7 @@ public class FileController : ControllerBase
         return Ok(files);
     }
 
+    [Authorize]
     [HttpGet("{fileId}/contents")]
     public async Task<IActionResult> GetFile([FromRoute] string fileId, CancellationToken ct)
     {
@@ -37,7 +38,7 @@ public class FileController : ControllerBase
         //Vi burde tilføje access token til dette senere
         var (stream, fileName) = await _fileService.GetFileAsync(fileId, ct);
         if (stream == null)
-        {
+        { 
             return NotFound();
         }
 

--- a/src/svc/storage/Program.cs
+++ b/src/svc/storage/Program.cs
@@ -102,9 +102,16 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.Configure<OpenFgaConfig>(
+    builder.Configuration.GetSection("OpenFga"));
+
+//builder.Services.AddHttpClient();
+builder.Services.AddHttpClient<IAuthorizationService, OpenFgaAuthorizationService>();
+
 builder.Services.AddScoped<IFileStorage, FileStorage>();
 builder.Services.AddScoped<IFileRepository, FileRepository>();
 builder.Services.AddScoped<IFileService, FileService>();
+//builder.Services.AddScoped<IAuthorizationService, OpenFgaAuthorizationService>();
 
 var app = builder.Build();
 

--- a/src/svc/storage/Program.cs
+++ b/src/svc/storage/Program.cs
@@ -9,6 +9,7 @@ using System.Security.Claims;
 using Storage.FileStorage;
 using Storage.Repositories;
 using System.ComponentModel;
+using Storage.Configuration;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/src/svc/storage/Services/IAuthorizationService.cs
+++ b/src/svc/storage/Services/IAuthorizationService.cs
@@ -1,0 +1,4 @@
+public interface IAuthorizationService
+{
+    Task<bool> CanViewFile(string userId, string fileId);
+}

--- a/src/svc/storage/Services/OpenFgaAuthorizationService.cs
+++ b/src/svc/storage/Services/OpenFgaAuthorizationService.cs
@@ -1,3 +1,7 @@
+using Storage.Configuration;
+using Storage.Services;
+using Microsoft.Extensions.Options;
+
 public class OpenFgaAuthorizationService : IAuthorizationService
 {
     private readonly HttpClient _http;

--- a/src/svc/storage/Services/OpenFgaAuthorizationService.cs
+++ b/src/svc/storage/Services/OpenFgaAuthorizationService.cs
@@ -1,0 +1,41 @@
+public class OpenFgaAuthorizationService : IAuthorizationService
+{
+    private readonly HttpClient _http;
+    private readonly OpenFgaConfig _config;
+
+    public OpenFgaAuthorizationService(HttpClient http, IOptions<OpenFgaConfig> config)
+    {
+        _http = http;
+        _config = config.Value;
+    }
+
+    public async Task<bool> CanViewFile(string userId, string fileId)
+    {
+        var request = new
+        {
+            tuple_key = new
+            {
+                user = $"user:{userId}",
+                relation = "can_view",
+                @object = $"file:{fileId}"
+            },
+            authorization_model_id = _config.AuthorizationModelId
+        };
+
+        var url = $"{_config.ApiUrl}/stores/{_config.StoreId}/check";
+
+        var response = await _http.PostAsJsonAsync(url, request);
+
+        if (!response.IsSuccessStatusCode)
+            return false;
+
+        var result = await response.Content.ReadFromJsonAsync<CheckResponse>();
+
+        return result?.allowed ?? false;
+    }
+
+    private class CheckResponse
+    {
+        public bool allowed { get; set; }
+    }
+}

--- a/src/svc/storage/appsettings.json
+++ b/src/svc/storage/appsettings.json
@@ -14,5 +14,10 @@
       "Issuer": "http://localhost:5039",
       "Audience": "fileshare"
     }
+  },
+  "OpenFga": {
+    "ApiUrl": "http://localhost:8080",
+    "StoreId": "YOUR_STORE_ID",
+    "AuthorizationModelId": "YOUR_MODEL_ID"
   }
 }


### PR DESCRIPTION
Introduce authorization integration with OpenFGA: add IAuthorizationService, implement OpenFgaAuthorizationService that calls the OpenFGA check endpoint, and register it via AddHttpClient. Add OpenFGA settings to appsettings.json and bind them in Program.cs. Also mark the file download endpoint with [Authorize] and apply a small controller cleanup (NotFound brace). This enables server-side permission checks for file access.