### PR TITLE
feat: Add auth logging and backchannel tracing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,7 @@ services:
       - "5136:9443" # mTLS
     environment:
       <<: [*kestrel-endpoints, *mtls-client]
+      Logging__LogLevel__Microsoft.AspNetCore.Authentication.JwtBearer: Trace
       ConnectionStrings__DefaultConnection: "Host=storage-db;Port=5432;Database=storage_db;Username=fileshare_user;Password=password"
       Authentication__Jwt__Issuer: "${INTERNAL_SERVICE_SCHEME}://auth:${INTERNAL_SERVICE_PORT}"
       Authentication__Jwt__Audience: "fileshare"
@@ -165,6 +166,7 @@ services:
       - "5036:9443" # mTLS
     environment:
       <<: [*kestrel-endpoints, *mtls-client]
+      Logging__LogLevel__Microsoft.AspNetCore.Authentication.JwtBearer: Trace
       ConnectionStrings__DefaultConnection: "Host=lock-db;Port=5432;Database=lock_db;Username=fileshare_user;Password=password"
       Authentication__Jwt__Issuer: "${INTERNAL_SERVICE_SCHEME}://auth:${INTERNAL_SERVICE_PORT}"
       Authentication__Jwt__Audience: "fileshare"
@@ -189,6 +191,7 @@ services:
       - "5020:9443" # mTLS
     environment:
       <<: [*kestrel-endpoints, *mtls-client]
+      Logging__LogLevel__Microsoft.AspNetCore.Authentication.JwtBearer: Trace
       Authentication__Jwt__Issuer: "${INTERNAL_SERVICE_SCHEME}://auth:${INTERNAL_SERVICE_PORT}"
       Authentication__Jwt__Audience: "fileshare"
       Services__Storage__BaseUrl: "${INTERNAL_SERVICE_SCHEME}://storage:${INTERNAL_SERVICE_PORT}"

--- a/src/shared/FileShare.Infrastructure/AuthLoggingExtensions.cs
+++ b/src/shared/FileShare.Infrastructure/AuthLoggingExtensions.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Logging;
+
+namespace FileShareApp.Infrastructure;
+
+public static class AuthLoggingExtensions
+{
+    /// <summary>
+    /// Configures JwtBearerOptions with detailed logging for token validation and network requests.
+    /// </summary>
+    public static void AddAuthLogging(this JwtBearerOptions options, ILogger logger)
+    {
+        // 1. Hook into Authentication Events
+        options.Events = new JwtBearerEvents
+        {
+            OnTokenValidated = context =>
+            {
+                logger.LogInformation("JWT Token validated successfully for {User}.", 
+                    context.Principal?.Identity?.Name ?? "unknown user");
+                return Task.CompletedTask;
+            },
+            OnAuthenticationFailed = context =>
+            {
+                logger.LogWarning(context.Exception, "JWT Authentication failed. Reason: {Message}", context.Exception.Message);
+                return Task.CompletedTask;
+            },
+            OnForbidden = context =>
+            {
+                logger.LogWarning("JWT Forbidden. User is authenticated but not authorized for this resource.");
+                return Task.CompletedTask;
+            }
+        };
+
+        // 2. Intercept the Backchannel HTTP Handler to log OIDC metadata and JWKS retrieval.
+        var innerHandler = options.BackchannelHttpHandler ?? new HttpClientHandler();
+        options.BackchannelHttpHandler = new LoggingHandler(innerHandler, logger);
+    }
+
+    private sealed class LoggingHandler : DelegatingHandler
+    {
+        private readonly ILogger _logger;
+
+        public LoggingHandler(HttpMessageHandler innerHandler, ILogger logger)
+            : base(innerHandler)
+        {
+            _logger = logger;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var sw = Stopwatch.StartNew();
+            _logger.LogInformation("Auth Network Request: {Method} {Uri}", request.Method, request.RequestUri);
+
+            try
+            {
+                var response = await base.SendAsync(request, cancellationToken);
+                sw.Stop();
+
+                if (response.IsSuccessStatusCode)
+                {
+                    _logger.LogInformation("Auth Network Response: {StatusCode} for {Uri} ({Elapsed}ms)", 
+                        (int)response.StatusCode, request.RequestUri, sw.ElapsedMilliseconds);
+                }
+                else
+                {
+                    _logger.LogWarning("Auth Network Response Error: {StatusCode} for {Uri} ({Elapsed}ms)", 
+                        (int)response.StatusCode, request.RequestUri, sw.ElapsedMilliseconds);
+                }
+
+                return response;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _logger.LogError(ex, "Auth Network Request Failed: {Uri} ({Elapsed}ms)", request.RequestUri, sw.ElapsedMilliseconds);
+                throw;
+            }
+        }
+    }
+}

--- a/src/shared/FileShare.Infrastructure/FileShare.Infrastructure.csproj
+++ b/src/shared/FileShare.Infrastructure/FileShare.Infrastructure.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/svc/lock/Program.cs
+++ b/src/svc/lock/Program.cs
@@ -57,6 +57,8 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     if (clientCert is not null)
         options.BackchannelHttpHandler = new HttpClientHandler
             { ClientCertificates = { clientCert } };
+
+    options.AddAuthLogging(startupLogger);
 });
 
 var lockGatewayPrefix = builder.Configuration["SwaggerGatewayPrefix"];

--- a/src/svc/storage/Program.cs
+++ b/src/svc/storage/Program.cs
@@ -62,6 +62,8 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     if (clientCert is not null)
         options.BackchannelHttpHandler = new HttpClientHandler
             { ClientCertificates = { clientCert } };
+
+    options.AddAuthLogging(startupLogger);
 });
 
 var storageGatewayPrefix = builder.Configuration["SwaggerGatewayPrefix"];

--- a/src/svc/wopi-host/Program.cs
+++ b/src/svc/wopi-host/Program.cs
@@ -57,6 +57,8 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     if (clientCert is not null)
         options.BackchannelHttpHandler = new HttpClientHandler
             { ClientCertificates = { clientCert } };
+
+    options.AddAuthLogging(startupLogger);
 });
 
 var wopiGatewayPrefix = builder.Configuration["SwaggerGatewayPrefix"];


### PR DESCRIPTION
Introduce detailed JWT/OIDC logging and trace network backchannel calls. Adds a new AuthLoggingExtensions class that hooks JwtBearerEvents (token validated, authentication failed, forbidden) and wraps the BackchannelHttpHandler to log request/response timing and errors. Wire up AddAuthLogging(startupLogger) in lock, storage and wopi-host services and add the JwtBearer package reference. Also enable trace-level logging for JwtBearer in docker-compose for the affected services to surface diagnostic output.